### PR TITLE
addtion of TChIC workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # scChICflow
 
-Workflow for processing of [single-cell sortChIC](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9925381/) data.
+Workflow for processing of [single-cell sortChIC](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9925381/) and [single-cell TChIC](https://www.biorxiv.org/content/10.1101/2024.05.09.593364v1.abstract) data.
 
 **Author: Vivek Bhardwaj (@vivekbhr)**
 
@@ -27,6 +27,12 @@ mamba env create -f env.yaml -n chicflow
 ```
 
 **Note:** Setup of this conda environment has been tested with linux, and conda v23. If it takes too long and/or creates conflicts, try removing the conflicting packages from the `env.yaml` file and installing them manually afterwards.
+
+Additionally the tool `split_fastq.py` needs to be installed manually for the TChIC workflow:
+
+```
+cd scChICflow/tools && python splitfastq_install.py build_ext --inplace && cd -
+```
 
 
 ### 3. Prepare the config.yaml

--- a/Snakefile
+++ b/Snakefile
@@ -51,22 +51,24 @@ include: os.path.join(workflow.basedir, "rules", "QC.snakefile")
 include: os.path.join(workflow.basedir, "rules", "peakcall.snakefile")
 if countRegions:
     include: os.path.join(workflow.basedir, "rules", "counting_sincei.snakefile")
-if protocol=='tChIC':
+if protocol=='tchic':
     include: os.path.join(workflow.basedir, "rules", "map_scRNAseq.snakefile")
+    outdir_rna='RNA_MAPPING_STAR'
 
 ### conditional/optional rules #################################################
 ################################################################################
-outdir_rna='RNA_MAPPING_STAR'
+
 def run_tchic_fastq(protocol):
     if protocol=='tchic':
-        file_list = ["QC/tChIC_split_stats.png",
-                     expand("FASTQ_RNA/{sample}{read}.fastq.gz", sample = samples, read = reads),
-                     expand("FASTQ_OTHER/{sample}.BOTH{read}.fastq.gz", sample = samples, read = reads),
-                     expand("FASTQ_OTHER/{sample}.NONE{read}.fastq.gz", sample = samples, read = reads)],
-                     expand(os.path.join(outdir_rna, "STARsolo/{sample}/{sample}.Solo.out/Gene/filtered/matrix.mtx"), sample = samples),
-                     expand(os.path.join(outdir_rna, "bigwigs/{sample}.bw"), sample = samples),
-                     os.path.join(outdir_rna, "QC/multiqc_report.html"),
-                     other]
+        file_list = [
+            "QC/tChIC_split_stats.png",
+            expand("FASTQ_RNA/{sample}{read}.fastq.gz", sample = samples, read = reads),
+            expand("FASTQ_OTHER/{sample}.BOTH{read}.fastq.gz", sample = samples, read = reads),
+            expand("FASTQ_OTHER/{sample}.NONE{read}.fastq.gz", sample = samples, read = reads),
+            expand(os.path.join(outdir_rna, "STARsolo/{sample}/{sample}.Solo.out/Gene/filtered/matrix.mtx"), sample = samples),
+            expand(os.path.join(outdir_rna, "bigwigs/{sample}.bw"), sample = samples),
+            os.path.join(outdir_rna, "QC/multiqc_report.html"),
+            ]
         return(file_list)
     else:
         return([])
@@ -77,10 +79,10 @@ def run_Trimming(trim):
         expand("QC/FastQC_trimmed/{sample}{read}_fastqc.html", sample = samples, read = reads)
         ]
         if protocol=='tchic':
-            file_list.append(
+            file_list.append([
             expand(os.path.join(outdir_rna, "FASTQ_trimmed/FastQC/{sample}{read}_fastqc.html"),
-                                sample = samples, read = reads)
-            )
+                                sample = samples, read = reads),
+            ])
         return(file_list)
     else:
         return([])
@@ -103,8 +105,7 @@ def post_mapping_steps():
         "QC/featureEnrichment.png",
         "QC/featureEnrichment_biotype.png",
         "QC/plate_plots.pdf",
-        "QC/scFilterStats.txt",
-        "QC/multiqc_report.html"
+        "QC/scFilterStats.txt"
     ]
 
     if len(samples) > 1:
@@ -123,7 +124,8 @@ rule all:
         expand("mapped_bam/{sample}.bam", sample = samples),
         expand("mapped_bam/{sample}.bam.bai", sample = samples),
         post_mapping_steps(),
-        count_regions()
+        count_regions(),
+        "QC/multiqc_report.html"
 
 ### execute after workflow finished ############################################
 ################################################################################

--- a/rules/QC.snakefile
+++ b/rules/QC.snakefile
@@ -63,13 +63,13 @@ rule scFilterStats:
         barcodes = barcode_list
     output: "QC/scFilterStats.txt"
     params:
-        path = sincei_path if sincei_path else "",
+        #path = sincei_path if sincei_path else "",
         blacklist = "-bl " + blacklist_bed if blacklist_bed else ""
     log: "logs/scFilterStats.log"
     threads: 15
     conda: CONDA_SHARED_ENV
     shell:
-        "{params.path}scFilterStats --motifFilter 'A,TA' \
+        "scFilterStats --motifFilter 'A,TA' \
         --minAlignedFraction 0.6 --GCcontentFilter '0.2,0.8' \
         --genome2bit {input.twobit} --barcodes {input.barcodes} {params.blacklist} \
         --smartLabels -p {threads} -o {output} -b {input.bams} > {log} 2>&1"

--- a/rules/QC.snakefile
+++ b/rules/QC.snakefile
@@ -50,7 +50,7 @@ rule plate_plot:
         rscript = os.path.join(workflow.basedir, "tools", "make_plate_plots.R")
     log: "logs/plate_plots.out"
     threads: 1
-    conda: CONDA_SHARED_ENV
+    #conda: CONDA_SHARED_ENV
     shell:
         "Rscript {params.rscript} {input.barcodes} {params.countdir} {output} > {log}"
 

--- a/rules/QC.snakefile
+++ b/rules/QC.snakefile
@@ -15,14 +15,15 @@ rule multiQC:
     input: get_multiqc_input()
     output: "QC/multiqc_report.html"
     params:
-        outdir = "QC"
+        outdir = "QC",
+        ignore = lambda wildcards: "FASTQ/*" if trim else ""
     log:
         out = "logs/multiqc.out",
         err = "logs/multiqc.err"
     threads: 1
     conda: CONDA_SHARED_ENV
     shell:
-        "multiqc -f -o {params.outdir} {params.outdir} > {log.out} 2> {log.err}"
+        "multiqc -f {params.ignore} -o {params.outdir} {params.outdir} > {log.out} 2> {log.err}"
 
 ## count deduplicated reads per cell
 rule countFrags_perCell:

--- a/rules/counting_sincei.snakefile
+++ b/rules/counting_sincei.snakefile
@@ -8,13 +8,13 @@ if countRegions == "windows":
         output: "counts/scCounts_"+binSize+"bp_bins.loom"
         params:
             bin = binSize,
-            prefix = "counts/scCounts_"+binSize+"bp_bins",
-            path = sincei_path if sincei_path else ""
+            prefix = "counts/scCounts_"+binSize+"bp_bins"
+            #path = sincei_path if sincei_path else ""
         log: "logs/sincei_count_windows.err"
         threads: 10
         conda: CONDA_SHARED_ENV
         shell:
-            "{params.path}scCountReads bins \
+            "scCountReads bins \
             --minAlignedFraction 0.6 --GCcontentFilter '0.2,0.8' \
             --barcodes {input.barcodes} \
             -bl {input.blk} \
@@ -34,12 +34,12 @@ elif countRegions == "bed" or countRegions == "peaks":
         params:
             bin = binSize,
             prefix = "counts/scCounts_"+countRegions,
-            path = sincei_path if sincei_path else ""
+            #path = sincei_path if sincei_path else ""
         log: "logs/sincei_count_bed.err"
         threads: 10
         conda: CONDA_SHARED_ENV
         shell:
-            "{params.path}scCountReads BED-file \
+            "scCountReads BED-file \
             --BED {input.bed} \
             --minAlignedFraction 0.6 --GCcontentFilter '0.2,0.8' \
             --barcodes {input.barcodes} \

--- a/rules/env.yaml
+++ b/rules/env.yaml
@@ -3,10 +3,13 @@ channels:
   - r
   - bioconda
   - conda-forge
+  - defaults
 dependencies:
  - r-base
  - r-magrittr
  - r-ggplot2
+ - r-tidyr
+ - r-dplyr
  - hisat2 >= 2.2.1
  - seqtk >= 1.3
  - pigz >= 2.3.4
@@ -19,6 +22,9 @@ dependencies:
  - bedtools >= 2.3
  - deeptools >= 3.5
  - macs2 >= 2.2.4
+ - biopython
+ - bbmap
+ - star == 2.7.11b
  - pip
  - pip:
     - sincei >= 0.3

--- a/rules/env.yaml
+++ b/rules/env.yaml
@@ -3,7 +3,7 @@ channels:
   - r
   - bioconda
   - conda-forge
-  - defaults
+#  - defaults
 dependencies:
  - r-base
  - r-magrittr
@@ -25,7 +25,8 @@ dependencies:
  - biopython
  - bbmap
  - star == 2.7.11b
+ - sincei >= 0.4
  - pip
  - pip:
-    - sincei >= 0.3
+#    - sincei >= 0.3
     - snakemake >= 5.5

--- a/rules/map_scRNAseq.Snakefile
+++ b/rules/map_scRNAseq.Snakefile
@@ -1,0 +1,177 @@
+# @author: Vivek Bhardwaj (@vivekbhr)
+## TODO: switch the star_bugfix path with star version 2.7.10b,
+import os
+import glob
+
+STARsoloCoords = [1, 6, 7, 8] ## UMI start, UMI length, Cell BC start, cell BC length (1-based)
+
+# optional args
+indir='FASTQ_RNA'
+outdir='RNA_MAPPING_STAR'
+
+if trim:
+    trim_dir = os.path.join(outdir, "FASTQ_trimmed")
+else:
+    trim_dir = indir
+
+if trim:
+    rule cutadapt_rna:
+        input:
+            R1 = os.path.join(indir,"{sample}"+reads[0]+".fastq.gz"),
+            R2 = os.path.join(indir,"{sample}"+reads[1]+".fastq.gz")
+        output:
+            R1 = temp(os.path.join(outdir, "FASTQ_trimmed", "{sample}"+reads[0]+".fastq.gz")),
+            R2 = temp(os.path.join(outdir, "FASTQ_trimmed", "{sample}"+reads[1]+".fastq.gz")),
+            QC = os.path.join(outdir, "QC", "cutadapt", "{sample}.out")
+        params:
+            opts = "-A W{'10'}"
+        threads: 10
+        resources:
+            mem_mb=50000
+        shell:
+            """
+            cutadapt -j {threads} {params.opts} -e 0.1 -q 16 -O 3 --trim-n --minimum-length 10 \
+            -a AGATCGGAAGAGC -A AGATCGGAAGAGC --nextseq-trim=16 \
+            -b TGGAATTCTCGGGTGCCAAGG -B TGGAATTCTCGGGTGCCAAGG \
+            -b ATCTCGTATGCCGTCTTCTGCTTG -B ATCTCGTATGCCGTCTTCTGCTTG \
+            -b GTTCAGAGTTCTACAGTCCGACGATC -B GTTCAGAGTTCTACAGTCCGACGATC \
+            -o "{output.R1}" -p "{output.R2}" "{input.R1}" "{input.R2}" > {output.QC}
+            """
+
+rule FastQC_rna:
+    input:
+        os.path.join(trim_dir, "{sample}{read}.fastq.gz")
+    output:
+        os.path.join(trim_dir, "FastQC/{sample}{read}_fastqc.html")
+    params:
+        outdir = os.path.join(trim_dir, "FastQC")
+    log:
+        out = os.path.join(outdir, "logs/FastQC.{sample}{read}.out"),
+        err = os.path.join(outdir, "logs/FastQC.{sample}{read}.err")
+    threads: 1
+    shell: "fastqc -o {params.outdir} {input} > {log.out} 2> {log.err}"
+
+# mapped using STARsolo so possible to split SAM files per cell type later on
+rule mapReads:
+    input:
+        read1 = os.path.join(trim_dir, "{sample}"+reads[0]+".fastq.gz"),
+        read2 = os.path.join(trim_dir, "{sample}"+reads[1]+".fastq.gz")
+    output:
+        bam = os.path.join(outdir, "STARsolo/{sample}/{sample}.Aligned.sortedByCoord.out.bam"),
+        raw_counts = os.path.join(outdir, "STARsolo/{sample}/{sample}.Solo.out/Gene/raw/matrix.mtx"),
+        filtered_counts = os.path.join(outdir, "STARsolo/{sample}/{sample}.Solo.out/Gene/filtered/matrix.mtx"),
+        filtered_bc = os.path.join(outdir, "STARsolo/{sample}/{sample}.Solo.out/Gene/filtered/barcodes.tsv"),
+        tmpdir=temp(directory(os.path.join(outdir, "STARsolo/{sample}/{sample}._STARtmp"))),
+        tmpgenome=temp(directory(os.path.join(outdir, "STARsolo/{sample}/{sample}._STARgenome")))
+    params:
+        star_bugfix='/hpc/hub_oudenaarden/vbhardwaj/programs/STAR-2.7.10a_alpha_220506/source',# use this unil version 2.7.11 is released, to avoid segfault
+        gtf_file = gtf_file,
+        index = star_index,
+        prefix = "STARsolo/{sample}/{sample}.",
+        samsort_memory = '2G',
+        sample_dir = "STARsolo/{sample}",
+        bclist = barcodes_cs2,
+        UMIstart = STARsoloCoords[0],
+        UMIlen = STARsoloCoords[1],
+        CBstart = STARsoloCoords[2],
+        CBlen = STARsoloCoords[3],
+        outdir = "STARsolo/",
+        tempDir = tempDir,
+        sample = "{sample}"
+    log: os.path.join(outdir, "logs/mapReads_{sample}.err")
+    threads: 20
+    resources:
+        mem_mb=100000
+    shell:
+        """
+    TMPDIR={params.tempDir}
+    MYTEMP=$(mktemp -d ${{TMPDIR:-/tmp}}/snakepipes.XXXXXXXXXX);
+    ( [ -d {params.sample_dir} ] || mkdir -p {params.sample_dir} )
+    maxIntronLen=`expr $(awk '{{ print $3-$2 }}' {params.index}/sjdbList.fromgtf_file.out.tab | sort -n -r | head -1) + 1`
+    {params.star_bugfix}/STAR --runThreadN {threads} \
+    --sjdbOverhang 100 \
+    --outSAMunmapped Within \
+    --outSAMtype BAM SortedByCoordinate \
+    --outBAMsortingBinsN 20 \
+    --genomeDir {params.index} \
+    --readFilesIn {input.read2} {input.read1}\
+    --readFilesCommand zcat \
+    --outFileNamePrefix {params.prefix} \
+    --outSAMattributes NH HI AS nM MD jM jI MC ch CB UB GX GN \
+    --outSAMstrandField intronMotif \
+    --sjdbgtf_filefile {params.gtf_file} \
+    --outFilterType BySJout \
+    --outFilterIntronMotifs RemoveNoncanonical \
+    --alignIntronMax ${{maxIntronLen}} \
+    --alignSJoverhangMin 8 \
+    --soloFeatures Gene Velocyto \
+    --soloCBstart {params.CBstart} \
+    --soloCBlen {params.CBlen} \
+    --soloUMIstart {params.UMIstart} \
+    --soloUMIlen {params.UMIlen} \
+    --soloCBwhitelist {params.bclist} \
+    --soloBarcodeReadLength 0 \
+    --soloStrand Forward \
+    --soloCBmatchWLtype Exact \
+    --soloType CB_UMI_Simple \
+    --soloUMIdedup NoDedup 2> {log}
+    rm -rf $MYTEMP
+        """
+
+#    --soloUMIdedup Exact
+rule filterBAMunique:
+    input: os.path.join(outdir, "STARsolo/{sample}/{sample}.Aligned.sortedByCoord.out.bam"),
+    output: temp(os.path.join(outdir, "STARsolo/{sample}.uniqueReads.sam"))
+    threads: 10
+    resources:
+        mem_mb=50000
+    shell:
+        "samtools view -@ {threads} -h -d CB -F 4 -F 256 -F 2048 -q 255 {input} | grep -w -v 'CB:Z:-' > {output}"
+
+rule dedupBAMunique:
+    input: os.path.join(outdir, "STARsolo/{sample}.uniqueReads.sam")
+    output:
+        bam=os.path.join(outdir, "STARsolo/{sample}.uniqueReads.bam"),
+        qc=os.path.join(outdir, "QC/umi_dedup/{sample}_per_umi_per_position.tsv")
+    params:
+        sample = "{sample}",
+        tempdir= tempDir
+    log: os.path.join(outdir, "logs/filterBAM.{sample}.log")
+    threads: 1
+    resources:
+        mem_mb=80000
+    shell:
+        """
+        umi_tools dedup --per-cell --cell-tag CB --umi-tag UB --extract-umi-method tag \
+        --method unique --spliced-is-unique \
+        --output-stats=QC/umi_dedup/{params.sample} \
+        --temp-dir {params.tempdir} -L {log} -i -I {input} > {output.bam}
+        """
+
+rule indexBAM:
+    input: "STARsolo/{sample}.uniqueReads.bam"
+    output: "STARsolo/{sample}.uniqueReads.bam.bai"
+    log: os.path.join(outdir, "logs/indexBAM.{sample}.log")
+    threads: 5
+    shell: 'samtools index -@ {threads} {input}'
+
+# Get bigwig files of the trimmed fastq files check for A/T stretches
+rule getBW:
+    input:
+        bam = os.path.join(outdir, "STARsolo/{sample}.uniqueReads.bam"),
+        idx = os.path.join(outdir, "STARsolo/{sample}.uniqueReads.bam.bai")
+    output: os.path.join(outdir, "bigwigs/{sample}.bw")
+    log: os.path.join(outdir, "logs/getBW_{sample}.err")
+    threads: 20
+    shell:
+        "bamCoverage -p {threads} --normalizeUsing CPM -b {input.bam} -o {output} > {log} 2>&1"
+
+rule multiQC:
+    input: expand(os.path.join(outdir, "STARsolo/{sample}.uniqueReads.bam"), sample = samples)
+    output: os.path.join(outdir, "QC/multiqc_report.html")
+    params:
+        outdir = os.path.join(outdir, "QC")
+    log: os.path.join(outdir, "logs/multiqc.log")
+    threads: 1
+    shell:
+        "multiqc -f -o {params.outdir} . > {log} 2>&1"

--- a/rules/map_scRNAseq.snakefile
+++ b/rules/map_scRNAseq.snakefile
@@ -65,7 +65,6 @@ rule rna_mapReads:
         tmpdir=temp(directory(os.path.join(outdir, "STARsolo/{sample}/{sample}._STARtmp"))),
         tmpgenome=temp(directory(os.path.join(outdir, "STARsolo/{sample}/{sample}._STARgenome")))
     params:
-        star_bugfix='/hpc/hub_oudenaarden/vbhardwaj/programs/STAR-2.7.10a_alpha_220506/source',# use this unil version 2.7.11 is released, to avoid segfault
         gtf_file = gtf_file,
         index = star_index,
         prefix = os.path.join(outdir, "STARsolo/{sample}/{sample}."),
@@ -90,7 +89,7 @@ rule rna_mapReads:
     MYTEMP=$(mktemp -d ${{TMPDIR:-/tmp}}/snakepipes.XXXXXXXXXX);
     ( [ -d {params.sample_dir} ] || mkdir -p {params.sample_dir} )
     maxIntronLen=`expr $(awk '{{ print $3-$2 }}' {params.index}/sjdbList.fromGTF.out.tab | sort -n -r | head -1) + 1`
-    {params.star_bugfix}/STAR --runThreadN {threads} \
+    STAR --runThreadN {threads} \
     --sjdbOverhang {params.spliceLen} \
     --outSAMunmapped Within \
     --outSAMtype BAM SortedByCoordinate \

--- a/rules/map_scRNAseq.snakefile
+++ b/rules/map_scRNAseq.snakefile
@@ -174,8 +174,9 @@ rule rna_multiQC:
     input: expand(os.path.join(outdir, "STARsolo/{sample}.uniqueReads.bam"), sample = samples)
     output: os.path.join(outdir, "QC/multiqc_report.html")
     params:
-        outdir = os.path.join(outdir, "QC")
+        qc_outdir = os.path.join(outdir, "QC"),
+        qc_indir = outdir
     log: os.path.join(outdir, "logs/multiqc.log")
     threads: 1
     shell:
-        "multiqc -f -o {params.outdir} . > {log} 2>&1"
+        "multiqc -f -o {params.qc_outdir} {params.qc_indir} > {log} 2>&1"

--- a/rules/map_scRNAseq.snakefile
+++ b/rules/map_scRNAseq.snakefile
@@ -87,7 +87,7 @@ rule rna_mapReads:
     TMPDIR={params.tempDir}
     MYTEMP=$(mktemp -d ${{TMPDIR:-/tmp}}/snakepipes.XXXXXXXXXX);
     ( [ -d {params.sample_dir} ] || mkdir -p {params.sample_dir} )
-    maxIntronLen=`expr $(awk '{{ print $3-$2 }}' {params.index}/sjdbList.fromgtf_file.out.tab | sort -n -r | head -1) + 1`
+    maxIntronLen=`expr $(awk '{{ print $3-$2 }}' {params.index}/sjdbList.fromGTF.out.tab | sort -n -r | head -1) + 1`
     {params.star_bugfix}/STAR --runThreadN {threads} \
     --sjdbOverhang 100 \
     --outSAMunmapped Within \
@@ -99,7 +99,7 @@ rule rna_mapReads:
     --outFileNamePrefix {params.prefix} \
     --outSAMattributes NH HI AS nM MD jM jI MC ch CB UB GX GN \
     --outSAMstrandField intronMotif \
-    --sjdbgtf_filefile {params.gtf_file} \
+    --sjdbGTFfile {params.gtf_file} \
     --outFilterType BySJout \
     --outFilterIntronMotifs RemoveNoncanonical \
     --alignIntronMax ${{maxIntronLen}} \
@@ -114,7 +114,7 @@ rule rna_mapReads:
     --soloStrand Forward \
     --soloCBmatchWLtype Exact \
     --soloType CB_UMI_Simple \
-    --soloUMIdedup NoDedup 2> {log}
+    --soloUMIdedup NoDedup > {log} 2>&1
     rm -rf $MYTEMP
         """
 

--- a/scChICflow
+++ b/scChICflow
@@ -69,8 +69,8 @@ def commonYAMLandLogs(baseDir, args, callingScript):
 
     if args.cluster:
         ## always --use-conda on cluster
-        snakemake_cmd += ["--use-conda --conda-frontend conda"]
-        snakemake_cmd += ["--conda-prefix " + args.conda_dir]
+        #snakemake_cmd += ["--use-conda --conda-frontend conda"]
+        #snakemake_cmd += ["--conda-prefix " + args.conda_dir]
         snakemake_cmd += ["--cluster-config",
                           os.path.join(baseDir, "cluster_config.yaml"),
                           "--cluster", "'" + cluster_config["cluster_cmd"], "'"]

--- a/scChICflow
+++ b/scChICflow
@@ -55,7 +55,7 @@ def commonYAMLandLogs(baseDir, args, callingScript):
 
     snakemake_cmd = """
                     TMPDIR={tempDir} PYTHONNOUSERSITE=True snakemake {snakemakeOptions} --directory {workingdir} --snakefile {snakefile} \
-                    --jobs {maxJobs} --configfile {configFile} --keep-going --latency-wait {latency_wait} 
+                    --jobs {maxJobs} --configfile {configFile} --keep-going --latency-wait {latency_wait}
                     """.format(snakefile=os.path.join(baseDir, "Snakefile"),
                                maxJobs=args.maxJobs,
                                workingdir=args.outdir,
@@ -69,7 +69,7 @@ def commonYAMLandLogs(baseDir, args, callingScript):
 
     if args.cluster:
         ## always --use-conda on cluster
-        snakemake_cmd += ["--use-conda --conda-frontend mamba"]
+        snakemake_cmd += ["--use-conda --conda-frontend conda"]
         snakemake_cmd += ["--conda-prefix " + args.conda_dir]
         snakemake_cmd += ["--cluster-config",
                           os.path.join(baseDir, "cluster_config.yaml"),

--- a/tools/splitfastq_install.py
+++ b/tools/splitfastq_install.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+from setuptools import setup
+from Cython.Build import cythonize
+
+setup(
+    name='splitfastq',
+    ext_modules=cythonize("splitfastq.pyx"),
+)


### PR DESCRIPTION
Major changes:
 - Supports [TChIC](https://www.biorxiv.org/content/10.1101/2024.05.09.593364v1.abstract) which includes splitting the fastq files and a VASA-seq mapping workflow
 - Uses a pre-installed version of [sincei](https://sincei.readthedocs.io/) , instead of a path to the executable
