### PR TITLE
HISAT2 Cluster workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ If the `--tempDir` flag does not match the `tmpdir` resource specified in `profi
 #### *Note on running HISAT2 on the cluster*
 Unfortunately, the current version of **HISAT2** (2.2.1) has a hard-coded directory for temporary files at `/tmp`. This may cause issues depending on cluster setup, since many clusters allocate temporary directory space at other locations such as `/scratch/$JOB_ID`. In case of HISAT2 issues, we recommend using the **bwa** aligner instead (specified via the `dna_aligner` flag on the workflow `config.yaml` file).
 
+As of HISAT 2.2.1, there is a workaround: in the HISAT2 installation the file `hisat2/hisat2` can be modified by changing line 241 from
+
+```
+my $temp_dir = "/tmp";
+```
+
+to
+
+```
+my $temp_dir = File::Spec->tmpdir();
+```
+
+This makes HISAT2 use the `$TMPDIR` environment variable instead of the hardcoded `/tmp`.
+
 ### Description of workflow steps
 
 **The following DAG (Directed Acyclic Graph) shows the processing steps inside the workflow (with protocol: chic)**

--- a/rules/fastq_map.snakefile
+++ b/rules/fastq_map.snakefile
@@ -99,14 +99,14 @@ rule chrSizes:
 
 filter_cmd = """ awk -v sample={params.sample} 'OFS="\\t" {{ if($0 ~ "^@") {{print $0}} else \
     {{ split($1,a,"_"); $1=""; gsub(/^[ \t]/, "", $0); print a[1]";BC:Z:"a[2]";RX:Z:"a[3], $0, "SM:Z:"sample"_"a[2], "BC:Z:"a[2], "RX:Z:"a[3], "MI:Z:"a[2]a[3] }} }}' |\
-    samtools sort -@ {params.cores} -T $TMPDIR/{params.sample} -o {output.bam} > {log.out} 2>> {log.err}
+    samtools sort -@ {threads} -T $TMPDIR/{params.sample} -o {output.bam} > {log.out} 2>> {log.err}
     """
 
 if dna_aligner == "hisat2" or dna_aligner == "hisat":
     dna_aligner = "hisat2"
-    mapping_cmd = "hisat2 -p {params.cores} --sensitive --no-spliced-alignment --no-mixed --no-discordant --no-softclip -X 1000 -x {params.idx} -1 {input.r1} -2 {input.r2} 2> {log.err} | samtools view -h {params.samfilter} | " + filter_cmd
+    mapping_cmd = "hisat2 -p {threads} --sensitive --no-spliced-alignment --no-mixed --no-discordant --no-softclip -X 1000 -x {params.idx} -1 {input.r1} -2 {input.r2} 2> {log.err} | samtools view -h {params.samfilter} | " + filter_cmd
 else:
-    mapping_cmd = "bwa mem -v 1 -T {params.mapq} -t {params.cores} {input.idx} {input.r1} {input.r2} 2> {log.err} | samtools view -h {params.samfilter} | " + filter_cmd
+    mapping_cmd = "bwa mem -v 1 -T {params.mapq} -t {threads} {input.idx} {input.r1} {input.r2} 2> {log.err} | samtools view -h {params.samfilter} | " + filter_cmd
 
 
 rule dna_bam_map:
@@ -122,10 +122,10 @@ rule dna_bam_map:
         samfilter='-F 4 -F 256',
         idx = hisat2_index if dna_aligner == "hisat2" else "",
         gtf = gtf_file,
-        cores = 24
     log:
         out = "logs/bam_map_{sample}.out",
         err = "logs/bam_map_{sample}.err"
+    threads: 24
     shell: mapping_cmd
 
 

--- a/rules/fastq_map.snakefile
+++ b/rules/fastq_map.snakefile
@@ -99,14 +99,14 @@ rule chrSizes:
 
 filter_cmd = """ awk -v sample={params.sample} 'OFS="\\t" {{ if($0 ~ "^@") {{print $0}} else \
     {{ split($1,a,"_"); $1=""; gsub(/^[ \t]/, "", $0); print a[1]";BC:Z:"a[2]";RX:Z:"a[3], $0, "SM:Z:"sample"_"a[2], "BC:Z:"a[2], "RX:Z:"a[3], "MI:Z:"a[2]a[3] }} }}' |\
-    samtools sort -@ {threads} -T $TMPDIR/{params.sample} -o {output.bam} > {log.out} 2>> {log.err}
+    samtools sort -@ {params.cores} -T $TMPDIR/{params.sample} -o {output.bam} > {log.out} 2>> {log.err}
     """
 
 if dna_aligner == "hisat2" or dna_aligner == "hisat":
     dna_aligner = "hisat2"
-    mapping_cmd = "hisat2 -p {threads} --sensitive --no-spliced-alignment --no-mixed --no-discordant --no-softclip -X 1000 -x {params.idx} -1 {input.r1} -2 {input.r2} 2> {log.err} | samtools view -h {params.samfilter} | " + filter_cmd
+    mapping_cmd = "hisat2 -p {params.cores} --sensitive --no-spliced-alignment --no-mixed --no-discordant --no-softclip -X 1000 -x {params.idx} -1 {input.r1} -2 {input.r2} 2> {log.err} | samtools view -h {params.samfilter} | " + filter_cmd
 else:
-    mapping_cmd = "bwa mem -v 1 -T {params.mapq} -t {threads} {input.idx} {input.r1} {input.r2} 2> {log.err} | samtools view -h {params.samfilter} | " + filter_cmd
+    mapping_cmd = "bwa mem -v 1 -T {params.mapq} -t {params.cores} {input.idx} {input.r1} {input.r2} 2> {log.err} | samtools view -h {params.samfilter} | " + filter_cmd
 
 
 rule dna_bam_map:
@@ -121,11 +121,11 @@ rule dna_bam_map:
         mapq = min_mapq,
         samfilter='-F 4 -F 256',
         idx = hisat2_index if dna_aligner == "hisat2" else "",
-        gtf = gtf_file
+        gtf = gtf_file,
+        cores = 24
     log:
         out = "logs/bam_map_{sample}.out",
         err = "logs/bam_map_{sample}.err"
-    threads: 24
     shell: mapping_cmd
 
 

--- a/rules/map_scRNAseq.snakefile
+++ b/rules/map_scRNAseq.snakefile
@@ -84,7 +84,6 @@ rule rna_mapReads:
         mem_mb=100000
     shell:
         """
-        TMPDIR={config[tempDir]}
         MYTEMP=$(mktemp -d ${{TMPDIR:-/tmp}}/snakepipes.XXXXXXXXXX);
         ( [ -d {params.sample_dir} ] || mkdir -p {params.sample_dir} )
         maxIntronLen=`expr $(awk '{{ print $3-$2 }}' {params.index}/sjdbList.fromGTF.out.tab | sort -n -r | head -1) + 1`
@@ -143,7 +142,6 @@ rule rna_dedupBAMunique:
         mem_mb=100000
     shell:
         """
-        TMPDIR={config[tempDir]}
         umi_tools dedup --per-cell --cell-tag CB --umi-tag UB --extract-umi-method tag \
         --method unique --spliced-is-unique \
         --output-stats={params.umistats} \


### PR DESCRIPTION
FIxes a small `$TMPDIR` formatting mistake in `rules/fastq_map.snakefile` and adds a note to `README.md` explaining a workaround for running HISAT2 in case of problems related to the `$TMPDIR` variable in some computing clusters.